### PR TITLE
AT_4870: Missing infusion Inline Edit css file added to header

### DIFF
--- a/docs/themes/default/include/header.tmpl.php
+++ b/docs/themes/default/include/header.tmpl.php
@@ -64,6 +64,7 @@ global $system_courses, $_custom_css, $db;
 	<link rel="shortcut icon" href="<?php echo $this->base_path; ?>favicon.ico" type="image/x-icon" />
 	<link rel="stylesheet" href="<?php echo $this->base_path.'themes/'.$this->theme; ?>/print.css" type="text/css" media="print" />
 	<link rel="stylesheet" href="<?php echo $this->base_path.'jscripts/infusion/framework/fss/css/fss-layout.css'; ?>" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->base_path.'jscripts/infusion/components/inlineEdit/css/InlineEdit.css'; ?>" type="text/css" />
 	<link rel="stylesheet" href="<?php echo $this->base_path.'themes/'.$this->theme; ?>/styles.css" type="text/css" />
 	<!--[if IE]>
 	  <link rel="stylesheet" href="<?php echo $this->base_path.'themes/'.$this->theme; ?>/ie_styles.css" type="text/css" />


### PR DESCRIPTION
Added Infusion missing inline edit css file to our header template for the default theme.
