### PR TITLE
ISSUE-4144: Printing the error message when user tries to preview the pa...

### DIFF
--- a/mods/_core/editor/preview.php
+++ b/mods/_core/editor/preview.php
@@ -22,7 +22,7 @@ $cid = intval($_POST['cid']);
 if ($cid == 0) {
 	require(AT_INCLUDE_PATH.'header.inc.php');
 	$missing_fields[] = _AT('content_id');
-	$msg->addError(array('EMPTY_FIELDS', $missing_fields));
+	$msg->printErrors(array('EMPTY_FIELDS', $missing_fields));
 	require (AT_INCLUDE_PATH.'footer.inc.php');
 	exit;
 }


### PR DESCRIPTION
...ge before saving, created while adding a new content.

When a user adds a new content page via mods/_core/editor/edit_content.php and tries to preview it before saving, an error should be generated. But at present, when we do so no error is printed and after that any other action leads to printing an error which says "Required field missing". Through this change, I have fixed this issue which leads to printing of error whenever page is not saved and "preview" action is applied.
