### PR TITLE
Issue 5210: Fixed Networking unset and side menu toggle 

### DIFF
--- a/include/header.inc.php
+++ b/include/header.inc.php
@@ -106,7 +106,7 @@ $custom_head .= '
 	<script src="'.AT_print($_base_path, 'url.base').'jscripts/lib/jquery.cookie.js" type="text/javascript"></script>
 	<script src="'.AT_print($_base_path, 'url.base').'jscripts/ATutorAutoLogout.js" type="text/javascript"></script>
 	<script type="text/javascript">
-	$(document).ready(function() {
+	$("body").load(function() {
         ATutor.autoLogout({
             timeLogout              : '.$session_timeout.',
             timeWarningBeforeLogout : '.$session_warning.',


### PR DESCRIPTION
This bug was arising due to a JS error: "Uncaught TypeError: Cannot call method 'append' of null".
I changed the call from $(document).ready to $("body").load since the body tag was not getting defined by the time $(document).ready was called and hence it returned append of null.
By changing it to body.load we can achieve the same. I have tested it on FireFox and Chrome and the side menu states are not lost when Networking tab is opened.
