### PR TITLE
Suggested simple fixes for clarity and spelling

### DIFF
--- a/install/include/step2.php
+++ b/install/include/step2.php
@@ -75,7 +75,7 @@ if (isset($errors)) {
 	</tr>
 	<tr>
 		<td class="row1"><span class="required" title="Required Field">*</span><b><label for="username">Database Username:</label></b><br />
-			The username to the database server.</td>
+			A username with administrative privileges on the database server.</td>
 		<td class="row1"><input type="text" name="db_login" id="username" value="<?php echo stripslashes(htmlspecialchars($_POST['db_login'])); ?>" class="formfield" /></td>
 	</tr>
 	<tr>

--- a/install/include/step7.php
+++ b/install/include/step7.php
@@ -28,6 +28,6 @@ and reset the permissions on the config.inc.php file to read only.</p>
 
 <form method="get" action="../login.php">
 	<div align="center">
-		<input type="submit" name="submit" value="&raquo; Log-in!" class="button" />
+		<input type="submit" name="submit" value="&raquo; Log in!" class="button" />
 	</div>
 </form>


### PR DESCRIPTION
Just these:
1. Make it clear what “database user” we are talking about. I was stuck a long time trying to figure out what kind of “database user” the installer was asking me for.
2. “Log-in” should be “Log in”. Spelling/punctuation error.
