### PR TITLE
Issue 4093: Fixed add content language

### DIFF
--- a/mods/_core/content/module.php
+++ b/mods/_core/content/module.php
@@ -30,7 +30,12 @@ $this->_pages['mods/_core/editor/arrange_content.php']['title_var']    = 'arrang
 $this->_pages['mods/_core/editor/arrange_content.php']['parent']   = 'mods/_core/content/index.php';
 $this->_pages['mods/_core/editor/arrange_content.php']['guide']     = 'instructor/?p=arrange_content.php';
 
-$this->_pages['mods/_core/editor/edit_content.php']['title_var'] = 'edit_content';
+if (!isset($_GET['cid']) && !isset($_POST['cid'])) {
+    $this->_pages['mods/_core/editor/edit_content.php']['title_var'] = 'add_content';
+} else {
+    $this->_pages['mods/_core/editor/edit_content.php']['title_var'] = 'edit_content';
+}
+
 $this->_pages['mods/_core/editor/edit_content.php']['parent']    = 'mods/_core/content/index.php';
 $this->_pages['mods/_core/editor/edit_content.php']['guide']     = 'instructor/?p=content_edit.php';
 


### PR DESCRIPTION
Ticket link: http://atutor.ca/atutor/mantis/view.php?id=4093

Previously, on clicking the "Add page" icon in the content menu, "Edit content" was being shown as the title of the page. I have fixed it. Now, "Create" is being shown as the title of the page on clicking  the "Add Page" icon. 

However, in the bug report, it was mentioned that "Edit Content" should get replaced with "Add Content". There is already a translation present for add_content as "Create" in atutor_language_text.sql. I have reused the same translation here to maintain uniformity and have not created a new translation.
