### PR TITLE
Issue 5396: editing an expired test shows a queryDB error

### DIFF
--- a/mods/_standard/tests/edit_test.php
+++ b/mods/_standard/tests/edit_test.php
@@ -87,11 +87,11 @@ if (isset($_POST['cancel'])) {
      *            make changes accordingly on line 255 as well.
      */
     $sql = "SELECT t.test_id, anonymous FROM %stests_results r NATURAL JOIN %stests t WHERE r.test_id = t.test_id AND r.test_id=%d";
-    $row_anonymous    = queryDB($sql, array(TABLE_PREFIX, TABLE_PREFIX, $tid), TRUE);
+    $row_anonymous    = queryDB($sql, array(TABLE_PREFIX, TABLE_PREFIX, $tid));
 
     if(count($row_anonymous) > 0){
         //If there are submission(s) for this test, anonymous field will not be altered.
-        $_POST['anonymous'] = $row_anonymous['anonymous'];
+        $_POST['anonymous'] = $row_anonymous[0]['anonymous'];
     }
 
     if ($missing_fields) {
@@ -307,7 +307,7 @@ $msg->printErrors();
         // This addresses the following issue: http://www.atutor.ca/atutor/mantis/view.php?id=3268
         // Ref: line 64
         $sql = "SELECT t.test_id, anonymous FROM %stests_results r NATURAL JOIN %stests t WHERE r.test_id = t.test_id AND r.test_id=%d";
-        $row_anon    = queryDB($sql, array(TABLE_PREFIX, TABLE_PREFIX, $tid), TRUE);
+        $row_anon    = queryDB($sql, array(TABLE_PREFIX, TABLE_PREFIX, $tid));
 
         $anonymous_disabled = FALSE;
         if(count($row_anon) > 0){


### PR DESCRIPTION
Ticket Link: http://atutor.ca/atutor/mantis/view.php?id=5396

I have removed the TRUE parameter passed for the queryDB function for finding whether submissions are made for the test or not. Clearly, this is a query which would return multiple results(multiple students have submitted the test results) and hence the third parameter($oneRow) should be FALSE(by default) since this parameter is used to make an extra check for queries that are supposed to return just 0 or 1 row.

Another thing I changed was at Line 94.
Steps to reproduce this bug: If an instructor has created a test as "Anonymous" and then he receives submissions from students. After this, when he edits the test, he would not be able to change the "Anonymous" option of the test since the radio button would be disabled. Still when he submits the edit form after making other changes like "Title, Description", the anonymous field would change to 0 in the db.
This happens because $row_anonymous['anonymous'] would not return any result since $row_anonymous would be a multi-dimensional array (Array=>(Array=>(test_id: 1, anonymous: 1), Array=>(test_id: 1, anonymous: 1))) and hence it takes 0 by default.
However, by using $row_anonymous[0]['anonymous'] the first row's anonymous field is retrieved.
