### PR TITLE
Issue 5320: Feedback after preview a disabled theme

### DIFF
--- a/include/install/db/atutor_language_text.sql
+++ b/include/install/db/atutor_language_text.sql
@@ -284,6 +284,7 @@ INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_ERROR_STUD_INFO_NOT_FOUND
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_ERROR_TERM_EXISTS', 'The term <strong>%s</strong> already exists.', '2004-07-22 16:55:03', '');
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_ERROR_THEME_NOT_DELETED', 'The theme could not be deleted because it is either the current default theme or the original default theme.', '2005-05-10 09:27:02', 'theme manager deleting theme');
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_ERROR_THEME_NOT_DISABLED', 'Theme cannot be disabled because it is currently the default theme.', '2005-05-09 14:27:23', '');
+INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_ERROR_THEME_PREVIEW_DISABLED', 'Theme must be enabled before previewing', '2013-12-08 14:27:23', '');
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_ERROR_TILE_AUTHENTICATION_FAIL', 'The AContent authentication fails at:<br />%s.', '2010-06-25 12:46:10', 'tile search');
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_ERROR_TILE_IMPORT_FAIL', 'AContent lesson import failed at:<br />%s', '2010-06-25 12:46:28', 'tile search');
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_ERROR_TOO_BIG_TO_UPLOAD', 'The file size %1s is too big to be uploaded.', '2012-07-25 11:42:21', '');

--- a/include/vitals.inc.php
+++ b/include/vitals.inc.php
@@ -237,6 +237,12 @@ require(AT_INCLUDE_PATH.'classes/Savant2/Savant2.php');       /* for the theme a
 $savant = new Savant2();
 $savant->addPath('template', AT_INCLUDE_PATH . '../themes/default/');
 
+/**************************************************/
+/* load in message handler                        */
+/**************************************************/
+require(AT_INCLUDE_PATH.'classes/Message/Message.class.php');
+$msg = new Message($savant);
+
 //if user has requested theme change, make the change here
 if ((isset($_POST['theme']) || isset($_POST['mobile_theme'])) && isset($_POST['submit'])) {
 	//http://atutor.ca/atutor/mantis/view.php?id=4781
@@ -282,10 +288,11 @@ if (isset($_SESSION['prefs']['PREF_THEME']) && isset($_SESSION['valid_user']) &&
 	if ($row['status'] == 0) {
 		// get user defined default theme if the preference theme is disabled
 		$default_theme = get_default_theme();
-		if (!is_dir(AT_SYSTEM_THEME_DIR . $default_theme['dir_name']) && !is_dir(AT_SUBSITE_THEME_DIR . $default_theme['dir_name'])) {
+		if (!is_dir(AT_SYSTEM_THEME_DIR . $default_theme) && !is_dir(AT_SUBSITE_THEME_DIR . $default_theme)) {
 			$default_theme = get_system_default_theme();
 		}
 		$_SESSION['prefs']['PREF_THEME'] = $default_theme;
+    $msg->addError('THEME_PREVIEW_DISABLED');
 	}
 }
 
@@ -305,11 +312,6 @@ if (is_customized_theme($_SESSION['prefs']['PREF_THEME'])) {
 
 define('AT_CUSTOMIZED_DATA_DIR', AT_BASE_HREF . $theme_path);
 
-/**************************************************/
-/* load in message handler                        */
-/**************************************************/
-require(AT_INCLUDE_PATH.'classes/Message/Message.class.php');
-$msg = new Message($savant);
 
 /**************************************************/
 /* load in content manager                        */


### PR DESCRIPTION
Ticket Link: http://atutor.ca/atutor/mantis/view.php?id=5320

I have added feedback error message when user tries to preview a disabled theme.
Also I have changed the if clause($default_theme['dir_name']) to $default_theme as get_default_theme() function returns a value and not an associative array.
