### PR TITLE
Issue 5301: No feedback after autoenroll

### DIFF
--- a/include/html/auto_enroll_courses.inc.php
+++ b/include/html/auto_enroll_courses.inc.php
@@ -20,17 +20,21 @@ if (isset($_REQUEST["en_id"]) && $_REQUEST["en_id"] <> "")
 
 	$associate_string = validate_enid($_REQUEST["en_id"]);
 
-	$sql_courses = "SELECT aec.course_id
+	$sql_courses = "SELECT aec.course_id, c.title
 	                  FROM %sauto_enroll a, 
-	                  %sauto_enroll_courses aec 
+	                  %sauto_enroll_courses aec,
+                    %scourses c
 	                  where a.associate_string='%s'
-	                  and a.auto_enroll_id = aec.auto_enroll_id";
+	                  and a.auto_enroll_id = aec.auto_enroll_id
+                    and aec.course_id = c.course_id";
 
-	$rows_courses = queryDB($sql_courses, array(TABLE_PREFIX, TABLE_PREFIX, $associate_string));
+	$rows_courses = queryDB($sql_courses, array(TABLE_PREFIX, TABLE_PREFIX, TABLE_PREFIX, $associate_string));
 		
 	if (count($rows_courses) > 0)  $_SESSION['enroll'] = AT_ENROLL_YES;
-	
+    
+  $course_names="";
 	foreach($rows_courses as $row_courses){
+    $course_names.='<li>'.$row_courses["title"].'</li>';
 		$course = $row_courses["course_id"];
 		$sql	= "SELECT access, member_id FROM %scourses WHERE course_id=%d";
 		$course_info = queryDB($sql, array(TABLE_PREFIX, $course), TRUE);	

--- a/include/install/db/atutor_language_text.sql
+++ b/include/install/db/atutor_language_text.sql
@@ -378,6 +378,7 @@ INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_FEEDBACK_LANG_UPDATED', '
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_FEEDBACK_LEFT_GROUP_SUCCESSFULLY', 'Successfully removed from group.', '2009-05-27 12:01:11', '');
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_FEEDBACK_LINK_ADDED', 'Link added successfully.  Link will become visible if approved.', '2005-02-23 12:07:59', '');
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_FEEDBACK_LOGIN_SUCCESS', 'You have logged in successfully.', '2012-08-20 10:38:28', '');
+INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_FEEDBACK_LOGIN_SUCCESS_AUTO_ENROLL', 'You have successfully logged in and have been successfully enrolled to the following courses: <ul> %s </ul>', '2013-12-16 10:39:43', '')
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_FEEDBACK_LOGOUT', 'You have successfully been logged out.', '2003-10-29 10:00:12', 'after logging out');
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_FEEDBACK_MASTER_LIST_NO_CHANGES', 'No changes were done to the Master Student List.', '2005-06-16 12:32:19', 'When action to master list yields no changes');
 INSERT INTO `language_text` VALUES ('en', '_msgs', 'AT_FEEDBACK_MASTER_LIST_UPLOADED', 'Master Student List has been updated successfully.', '2005-04-04 16:12:52', '');

--- a/registration.php
+++ b/registration.php
@@ -309,7 +309,10 @@ if (isset($_POST['cancel'])) {
 			$sql = "UPDATE %smembers 
 			           SET last_login=now(), creation_date=creation_date 
 			         WHERE member_id=%d";
-			queryDB($sql, array(TABLE_PREFIX, $member_id));			
+			queryDB($sql, array(TABLE_PREFIX, $member_id));	
+            
+        $msg->addFeedback(array(LOGIN_SUCCESS_AUTO_ENROLL,$course_names));
+            
 			// auto login
 			$_SESSION['valid_user'] = true;
 			$_SESSION['member_id']	= $m_id;


### PR DESCRIPTION
Ticket Link : http://atutor.ca/atutor/mantis/view.php?id=5301

I changed the query $sql_courses to include the course title as well and created a list element for each course enrolled.
Finally in registration.php, I add the feedback message which includes all the course names auto-enrolled.
