### PR TITLE
Issue: 5437 and 5428 fixed apostrophe issue in glossary

### DIFF
--- a/include/lib/output.inc.php
+++ b/include/lib/output.inc.php
@@ -964,7 +964,8 @@ function format_content($input, $html = 0, $glossary, $simple = false) {
             $term = preg_quote($term, "/");
             $term = '(\s*'.$term.'\s*)';
             $term = str_replace(' ','((<br \/>)*\s*)', $term); 
-            
+            $term = html_entity_decode($term, ENT_QUOTES);
+			
             // Uncomment the line below and comment the following line
             // when the jquery UI tooltip supports the html display.
             //$def = htmlspecialchars($v, ENT_QUOTES, 'UTF-8');
@@ -978,13 +979,12 @@ function format_content($input, $html = 0, $glossary, $simple = false) {
             } else {
                 $input = preg_replace
                         ("/(\[\?\])".$term."(\[\/\?\])/i",
-                        '<a class="tooltip" href="'.$_base_path.'mods/_core/glossary/index.php?g_cid='.$_SESSION['s_cid'].htmlentities(SEP).'w='.urlencode($original_term).'#term" title="'.htmlentities_utf8($original_term).': '.$def.'">\\2</a>',$input);
+                        '<a class="tooltip" href="'.$_base_path.'mods/_core/glossary/index.php?g_cid='.$_SESSION['s_cid'].htmlentities(SEP).'w='.urlencode($original_term).'#term" title="'.$original_term.': '.$def.'">\\2</a>',$input);
             }
         }
-    } else if (!$user_glossary) {
-        $input = str_replace(array('[?]','[/?]'), '', $input);
-    }
-        
+    } 
+    $input = str_replace(array('[?]','[/?]'), '', $input);
+    
     $input = str_replace('CONTENT_DIR', '', $input);
 
     if (isset($_config['latex_server']) && $_config['latex_server']) {

--- a/mods/_core/glossary/tools/add.php
+++ b/mods/_core/glossary/tools/add.php
@@ -63,8 +63,6 @@ if (isset($_POST['submit'])) {
 				$_POST['word'][$i]         = $addslashes($_POST['word'][$i]);
 				$_POST['definition'][$i]   = $addslashes($_POST['definition'][$i]);
 				$_POST['related_term'][$i] = $addslashes($_POST['related_term'][$i]);
-
-				$terms_sql .= "(NULL, $_SESSION[course_id], '{$_POST[word][$i]}', '{$_POST[definition][$i]}', {$_POST[related_term][$i]})";
 			}
 		}
 	}
@@ -76,8 +74,8 @@ if (isset($_POST['submit'])) {
 
 	if (!$msg->containsErrors()) {
 
-		$sql = "INSERT INTO %sglossary VALUES $terms_sql";
-		$result = queryDB($sql, array(TABLE_PREFIX), false, false);
+		$sql = "INSERT INTO %sglossary VALUES (NULL, $_SESSION[course_id], '%s', '%s', %s)";
+		$result = queryDB($sql, array(TABLE_PREFIX, implode("",$_POST['word']), implode("",$_POST['definition']), implode("",$_POST['related_term'])), false, true);
 
 		$msg->addFeedback('ACTION_COMPLETED_SUCCESSFULLY');
         $return_url = $_SESSION['tool_origin']['url'];


### PR DESCRIPTION
Ticket Link: http://atutor.ca/atutor/mantis/view.php?id=5437
and            http://atutor.ca/atutor/mantis/view.php?id=5428

Issue 5437: Manage>Add Glossary Term : It is now accepting any term comprising of apostrophe, which earlier showed error

Issue 5428: Manage>Content>Create:1. In case of no glossary word it will not show [?] word [/?]
2. It now compares words with apostrophe and shows a link to the glossary word.
