### PR TITLE
ISSUE 5439: Fixed default button in timeout dialog

### DIFF
--- a/jscripts/ATutorAutoLogout.js
+++ b/jscripts/ATutorAutoLogout.js
@@ -53,12 +53,12 @@ var ATutor = ATutor || {};
         };
         
         // Buttons for the sessionTimeout dialog
-        buttonOptions[textButtonLogout] = sessionLogout;
         buttonOptions[textButtonStayConnected] = function() {
             $(this).dialog("close");
             writeCookieTime();
             startCountdown();
         };
+        buttonOptions[textButtonLogout] = sessionLogout;
         
         // Create dialog for the page
         $("body").append("<div title='"+ options.title +"' id='sessionTimeout-dialog'>"+ options.message +"</div>");


### PR DESCRIPTION
Ticket : http://atutor.ca/atutor/mantis/view.php?id=5439
Rearranged the buttons to bring 'Stay Connected' before 'Logout', hence making it a default selection. User can now continue session on a single enter press
