### PR TITLE
Issue 5438: Content Navigation spacing and indentation

### DIFF
--- a/include/classes/ContentManager.class.php
+++ b/include/classes/ContentManager.class.php
@@ -1054,7 +1054,7 @@ class ContentManager
 						if($_SESSION['prefs']['PREF_NUMBERING']){
 						  $link .= $path.$counter;
 						}
-						$link .= ContentManager::cleanOutput($content['title']).'</span></strong>';
+						$link .= '&nbsp;'.ContentManager::cleanOutput($content['title']).'</span></strong>';
 						
 						// instructors have privilege to delete content
 						if (authenticate(AT_PRIV_CONTENT, AT_PRIV_RETURN) && !is_mobile_device()) {


### PR DESCRIPTION
Added spacing between the Content Numbering and content name which disappeared on selecting a particular content.
Adjusted improper indentation in the file
