### PR TITLE
autoLogin logout fix done

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -16,6 +16,15 @@ $_user_location	= 'public';
 define('AT_INCLUDE_PATH', 'include/');
 require(AT_INCLUDE_PATH.'vitals.inc.php');
 
+if ( isset($_COOKIE['ATLogin'], $_COOKIE['ATPass'])){
+  $parts = parse_url($_base_href);
+  unset($_COOKIE['ATLogin']);
+  unset($_COOKIE['ATPass']);
+
+  ATutor.setcookie('ATLogin','',time()-3600, $parts['path']);
+  ATutor.setcookie('ATPass','',time()-3600, $parts['path']);
+}
+
 $sql = "DELETE FROM %susers_online WHERE member_id=%d";
 queryDB($sql, array(TABLE_PREFIX, $_SESSION['member_id']));
 


### PR DESCRIPTION
If a user sets Auto Login feature as enabled:
Before: after clicking on logout, user still remained in the session.
After changes: Now on clicking logout with Auto Login feature enabled, if a user clicks on logout, session is destroyed and user is redirected to login page.
