### PR TITLE
Issue 5449: No Questions displayed if test settings set to one question per page

### DIFF
--- a/mods/_standard/tests/take_test_q.php
+++ b/mods/_standard/tests/take_test_q.php
@@ -235,7 +235,7 @@ if ($test_row['random']) {
 
 $question_row	= queryDB($sql, array(TABLE_PREFIX, TABLE_PREFIX, TABLE_PREFIX, $result_id, $tid, $pos), TRUE);
 
-if (!$result || !$question_row) {
+if (count($question_row)==0) {
 	echo '<p>'._AT('no_questions').'</p>';
 	require(AT_INCLUDE_PATH.'footer.inc.php');
 	exit;


### PR DESCRIPTION
Ticket Link: http://atutor.ca/atutor/mantis/view.php?id=5449

Removed $result from the if condition which was causing the problem and replaced !$question_row with count($question_row)==0
