### PR TITLE
Fix for security issue that means the entire login process can be bypassed

### DIFF
--- a/confirm.php
+++ b/confirm.php
@@ -82,7 +82,7 @@ if (isset($_GET['e'], $_GET['id'], $_GET['m'])) {
 				require(AT_INCLUDE_PATH.'header.inc.php');
 				echo "<div class=\"input-form\">";
 				require(AT_INCLUDE_PATH.'html/auto_enroll_list_courses.inc.php');
-				echo '<p style="text-align:center"><a href="'. $_SERVER['PHP_SELF'] . '?auto_login=1&member_id='. $id .'">' . _AT("go_to_my_start_page") . '</a></p>';
+				echo '<p style="text-align:center"><a href="'. $_SERVER['PHP_SELF'] . '?auto_login=1&member_id='. $id .'&code=' . $code .'">' . _AT("go_to_my_start_page") . '</a></p>';
 				echo "</div>";
 				require(AT_INCLUDE_PATH.'footer.inc.php');
 				exit;
@@ -94,6 +94,7 @@ if (isset($_GET['e'], $_GET['id'], $_GET['m'])) {
 				// enable auto login student into "my start page"
 				$_REQUEST["auto_login"] = 1;
 				$_REQUEST["member_id"] = $id;
+				$_REQUEST["code"] = $code;
 			}
 		} else {
 			$msg->addError('CONFIRM_BAD');
@@ -142,8 +143,10 @@ if (isset($_REQUEST['auto_login']))
 	
 	$sql = "SELECT M.member_id, M.login, M.preferences, M.language FROM %smembers M WHERE M.member_id=%d";
 	$row = queryDB($sql, array(TABLE_PREFIX, $_REQUEST["member_id"]), TRUE);
+
+	$code = substr(md5($e . $row['creation_date'] . $id), 0, 10);
 	
-	if ($row['member_id'] != '') 
+	if ($row['member_id'] != '' && isset($_REQUEST['code']) && $_REQUEST['code'] == $code) 
 	{
 		$_SESSION['valid_user'] = true;
 		$_SESSION['member_id']	= $_REQUEST["member_id"];


### PR DESCRIPTION
By going to /confirm.php?auto_login=1&member_id=X (X replaced with a number), it is possible to login as any user of the system. 

I've just added a requirement for the same 'confirmation code' to be required in the $_REQUEST global variable as is needed as part of the confirmation process.
