### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+content
+include/config.inc.php


### PR DESCRIPTION
Why is there no .gitignore file?

When cloning the repository and installing ATutor, I encounter quite a few untracked files. This takes care of that. =)
