### PR TITLE
Fix a XSS vulnerability in mods/_core/users/admins/detail_log.php

### DIFF
--- a/include/lib/vital_funcs.inc.php
+++ b/include/lib/vital_funcs.inc.php
@@ -1164,4 +1164,14 @@ function tool_origin($path=''){
     }
 }
 
+/**
+ * XSS safe echo replacement
+ * @param	string	$text	The text that should be displayed
+ * @param string	$encoding	The encoding of the text
+ * @date	Jan 11, 2016
+ */
+function xecho($text, $encoding='UTF-8') {
+	echo htmlspecialchars($text, ENT_QUOTES, $encoding);
+}
+
 ?>

--- a/mods/_core/users/admins/detail_log.php
+++ b/mods/_core/users/admins/detail_log.php
@@ -45,8 +45,8 @@ $operations[AT_ADMIN_LOG_OTHER] = _AT('other');
 
 ?>
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>">
-<input type="hidden" name="p" value="<?php echo $_GET['p']; ?>" />
-<input type="hidden" name="login" value="<?php echo $_GET['login']; ?>" />
+<input type="hidden" name="p" value="<?php xecho($_GET['p']); ?>" />
+<input type="hidden" name="login" value="<?php xecho($_GET['login']); ?>" />
 <div class="input-form">
 	<div class="row">
 		<?php echo _AT('date'); ?><br />


### PR DESCRIPTION
An unescaped GET parameter allows an attacker to perform a XSS attack
against any user with admin privileges.

The bug can be exploited via a handcrafted URL like this one:

```
https://ATutor.tld/mods/_core/users/admins/detail_log.php?p="><script>alert("XSS")</script><input
value="
```