### PR TITLE
Update editor_tab_functions.inc.php

### DIFF
--- a/mods/_core/editor/editor_tab_functions.inc.php
+++ b/mods/_core/editor/editor_tab_functions.inc.php
@@ -642,7 +642,7 @@ function write_temp_file() {
 		$content_base .= $_POST['content_path'] . '/';
 	}
 
-	$file_name = $_POST['cid'].'.html';
+	$file_name = basename($_POST['cid']).'.html';
 
 	if ($handle = fopen(AT_CONTENT_DIR . $file_name, 'wb+')) {
 		


### PR DESCRIPTION
the basename() patch is fine here also, because you write into the AT_CONTENT_DIR which should not be in the web root by default. This is a patch for the http://www.atutor.ca/atutor/mantis/view.php?id=5658 bug (RCE)