### PR TITLE
Fixes mysql_query to dbquery && fatal error on save social prefs

### DIFF
--- a/mods/_standard/social/lib/classes/PrivacyControl/PrivacyController.class.php
+++ b/mods/_standard/social/lib/classes/PrivacyControl/PrivacyController.class.php
@@ -134,7 +134,7 @@ class PrivacyController{
 		global $db, $addslashes;
 
 		$member_id = intval($member_id);
-		$prefs = $addslashes(serialize($prefs));
+		$prefs = serialize($prefs);
 
 		//TODO: Change it back to update
 		$sql = "REPLACE %ssocial_privacy_preferences SET member_id=%d, preferences='%s'";

--- a/profile.php
+++ b/profile.php
@@ -32,7 +32,7 @@ $profile_row = queryDB($sql,array(TABLE_PREFIX, $_GET['id']), TRUE);
 if (count($profile_row) > 0) {	
 	//get privs
 	$sql	= 'SELECT `privileges`, approved FROM %scourse_enrollment WHERE member_id=%d';
-	$row_en = mysql_query($sql,array(TABLE_PREFIX, $_GET['id']));
+	$row_en = queryDB($sql,array(TABLE_PREFIX, $_GET['id']));
 
 	if ($system_courses[$_SESSION['course_id']]['member_id'] == $_GET['id']) {
 		$status = _AT('instructor');


### PR DESCRIPTION
mysql_query() to dbquery() in profile.
Serialize with slashes inside returning bad serialized string when ATutor read social settings.
Great Libre Web Learning in french comming soon (c'est du boulot a traduire)