### PR TITLE
fix toggle no work due an window.opener.document access denied

### DIFF
--- a/jscripts/ATutor.js
+++ b/jscripts/ATutor.js
@@ -578,7 +578,8 @@ ATutor.users.preferences = ATutor.users.preferences || {};
         var pref_style = ATutor.users.preferences.user_styles.replace(/FONT_FAMILY/g, font_style).replace(/FONT_SIZE/g, font_size_style).replace(/BG_COLOR/g, bg_color_style).replace(/FG_COLOR/g, fg_color_style).replace(/HL_COLOR/g, hl_color_style).replace(/BORDER/g, bd_color_style);
 
         jQuery('#pref_style').replaceWith(pref_style);
-        if ((typeof window.opener === "object") && (window.opener !== null) ) {//users/pref_wizard/index.php popup style
+        // 5725 workaround to fix missing menu toggle images 
+        if ((typeof window.opener === "object") && (window.opener !== null) ) {
             jQuery('#pref_style', window.opener.document).replaceWith(pref_style);
         }
     };

--- a/jscripts/ATutor.js
+++ b/jscripts/ATutor.js
@@ -579,7 +579,7 @@ ATutor.users.preferences = ATutor.users.preferences || {};
         
         jQuery('#pref_style').replaceWith(pref_style);
         if (window.opener) {
-            jQuery('#pref_style', window.opener.document).replaceWith(pref_style);
+            try {jQuery('#pref_style', window.opener.document).replaceWith(pref_style);}catch(err){}finally{}
         }
     };
     

--- a/jscripts/ATutor.js
+++ b/jscripts/ATutor.js
@@ -576,10 +576,10 @@ ATutor.users.preferences = ATutor.users.preferences || {};
         
         //var pref_style = ATutor.users.preferences.user_styles.replace(/FONT_FAMILY/g, font_style).replace(/FONT_SIZE/g, font_size_style).replace(/BG_COLOR/g, bg_color_style).replace(/FG_COLOR/g, fg_color_style).replace(/HL_COLOR/g, hl_color_style);
         var pref_style = ATutor.users.preferences.user_styles.replace(/FONT_FAMILY/g, font_style).replace(/FONT_SIZE/g, font_size_style).replace(/BG_COLOR/g, bg_color_style).replace(/FG_COLOR/g, fg_color_style).replace(/HL_COLOR/g, hl_color_style).replace(/BORDER/g, bd_color_style);
-        
+
         jQuery('#pref_style').replaceWith(pref_style);
-        if (window.opener) {
-            try {jQuery('#pref_style', window.opener.document).replaceWith(pref_style);}catch(err){}finally{}
+        if ((typeof window.opener === "object") && (window.opener !== null) ) {//users/pref_wizard/index.php popup style
+            jQuery('#pref_style', window.opener.document).replaceWith(pref_style);
         }
     };
     


### PR DESCRIPTION
Prevent for continue to interpret javascript if stopping with
Error: Permission denied to access property "document"
Maybe rule browser "Same-origin policy" or unexisting object.

On course sidebar, toggle unwork & print "toggle" in place of +
for simply see this (js) error, go to login.php ;-)

this function is called in jscript/ATutor_js.php on line 381
ATutor.users.preferences.setStyles()