### PR TITLE
Fixes to cross site request forgery (CSRF) vulnerabilities for administrator actions

### DIFF
--- a/admin/config_edit.php
+++ b/admin/config_edit.php
@@ -22,6 +22,8 @@ if (isset($_POST['cancel'])) {
 	header('Location: index.php');
 	exit;
 } else if (isset($_POST['submit'])) {
+	check_csrf_token();
+
 	$missing_fields = array();
 
 	$_POST['site_name']          = trim($_POST['site_name']);

--- a/include/lib/vital_funcs.inc.php
+++ b/include/lib/vital_funcs.inc.php
@@ -681,6 +681,19 @@ function check_referer(){
     }
 }
 /**
+ * Check if token supplied in a POST request corresponds to the token in memory to prevent CSRF access
+ * @access public
+ * @return error message access denied
+ */
+function check_csrf_token() {
+	global $msg;
+	if($_POST['csrftoken'] != $_SESSION['token']){
+		$msg->addError('ACCESS_DENIED');
+		header('Location: '.AT_BASE_HREF.'index.php');
+		exit;
+	}
+}
+/**
  * Check if the give theme is a subsite customized theme. Return true if it is, otherwise, return false
  * @access public
  * @param string $theme_name

--- a/mods/_core/courses/admin/create_course.php
+++ b/mods/_core/courses/admin/create_course.php
@@ -23,6 +23,8 @@ if (isset($_POST['cancel'])) {
 	header('Location: '.AT_BASE_HREF.'mods/_core/courses/admin/courses.php');
 	exit;
 } else if (isset($_POST['form_course'])) {
+	check_csrf_token();
+
 	$errors = add_update_course($_POST, TRUE);
 	if ($errors !== FALSE) {
 		$msg->addFeedback('ACTION_COMPLETED_SUCCESSFULLY');

--- a/mods/_core/courses/users/create_course.php
+++ b/mods/_core/courses/users/create_course.php
@@ -68,12 +68,9 @@ if (isset($_POST['cancel'])) {
 	header('Location: index.php');
 	exit;
 }else if (isset($_POST['form_course']) && $_POST['submit'] != '') {
+	check_csrf_token();
+
 	$_POST['instructor'] = $_SESSION['member_id'];
-    if($_POST['csrftoken'] != $_SESSION['token']){
-        $msg->addError('ACCESS_DENIED');
-        header('Location: '.AT_BASE_HREF.'index.php');
-        exit;
-    } 
 	$errors = add_update_course($_POST);
 
 	if ($errors !== FALSE) {

--- a/mods/_core/enrolment/html/enroll_edit.inc.php
+++ b/mods/_core/enrolment/html/enroll_edit.inc.php
@@ -234,6 +234,8 @@ if (isset($_POST['submit_no'])) {
 	exit;
 }
 else if (isset($_POST['submit_yes']) && $_POST['func'] =='unenroll' ) {
+	check_csrf_token();
+
 	//Unenroll student from course
 	unenroll($_POST['id']);
 
@@ -241,6 +243,8 @@ else if (isset($_POST['submit_yes']) && $_POST['func'] =='unenroll' ) {
 	header('Location: index.php?current_tab=4'.SEP.'course_id='.$course_id);
 	exit;
 } else if (isset($_POST['submit_yes']) && $_POST['func'] =='enroll' ) {
+	check_csrf_token();
+
 	//Enroll student in course
 	enroll($_POST['id']);
 
@@ -248,6 +252,8 @@ else if (isset($_POST['submit_yes']) && $_POST['func'] =='unenroll' ) {
 	header('Location: index.php?current_tab=0'.SEP.'course_id='.$course_id);
 	exit;
 } else if (isset($_POST['submit_yes']) && $_POST['func'] =='alumni' ) {
+	check_csrf_token();
+
 	//Mark student as course alumnus
 	alumni($_POST['id']);
 	
@@ -289,6 +295,7 @@ $hidden_vars['func']     = $_GET['func'];
 $hidden_vars['current_tab'] = $_GET['current_tab'];
 $hidden_vars['gid']		 = abs($_GET['gid']);
 $hidden_vars['course_id'] = $course_id;
+$hidden_vars['csrftoken'] = $_SESSION['token'];
 //get usernames of users about to be edited
 $str = get_usernames($member_ids);
 

--- a/mods/_core/properties/admin/delete_course.php
+++ b/mods/_core/properties/admin/delete_course.php
@@ -22,6 +22,8 @@ if (isset($_POST['submit_no'])) {
 	header('Location: ../../courses/admin/courses.php');
 	exit;
 } else if (isset($_POST['step']) && ($_POST['step'] == 2) && isset($_POST['submit_yes'])) {
+	check_csrf_token();
+
 	require_once(AT_INCLUDE_PATH.'../mods/_core/file_manager/filemanager.inc.php');
 	require(AT_INCLUDE_PATH.'../mods/_core/properties/lib/delete_course.inc.php');
 
@@ -43,6 +45,7 @@ if (!isset($_POST['step'])) {
 } else if ($_POST['step'] == 1) {
 	$hidden_vars['step']   = 2;
 	$hidden_vars['course'] = $course;
+	$hidden_vars['csrftoken'] = $_SESSION['token'];
 	$msg->addConfirm(array('DELETE_COURSE_2', $system_courses[$course]['title']), $hidden_vars);
 	$msg->printConfirm();
 }

--- a/mods/_core/properties/admin/edit_course.php
+++ b/mods/_core/properties/admin/edit_course.php
@@ -22,6 +22,8 @@ if (isset($_POST['cancel'])) {
 	header('Location: ../../courses/admin/courses.php');
 	exit;
 } else if (isset($_POST['submit'])) {
+	check_csrf_token();
+
 	require(AT_INCLUDE_PATH.'../mods/_core/courses/lib/course.inc.php');
 	$errors = add_update_course($_POST, TRUE);
 

--- a/mods/_core/users/admin_delete.php
+++ b/mods/_core/users/admin_delete.php
@@ -147,7 +147,8 @@ function delete_user($id) {
 $ids = explode(',', $_REQUEST['id']);
 
 if (isset($_POST['submit_yes'])) {
-	
+	check_csrf_token();
+
 	foreach($ids as $id) {
 		delete_user(intval($id));
 	}
@@ -174,6 +175,7 @@ $names = get_login($ids);
 $names_html = '<ul>'.html_get_list($names).'</ul>';
 $hidden_vars['id'] =  implode(',', array_keys($names));
 $hidden_vars['ml'] = intval($_REQUEST['ml']);
+$hidden_vars['csrftoken'] = $_SESSION['token'];
 
 $confirm = array('DELETE_USER', $names_html);
 $msg->addConfirm($confirm, $hidden_vars);

--- a/mods/_core/users/admin_email.php
+++ b/mods/_core/users/admin_email.php
@@ -21,6 +21,8 @@ if ($_POST['cancel']) {
 	header('Location: users.php#feedback');
 	exit;
 } else if ($_POST['submit']) {
+	check_csrf_token();
+
 	$missing_fields = array();
 
 	$_POST['subject'] = trim($_POST['subject']);

--- a/mods/_core/users/admins/delete.php
+++ b/mods/_core/users/admins/delete.php
@@ -23,6 +23,8 @@ if (isset($_POST['submit_no'])) {
 	header('Location: index.php');
 	exit;
 } else if (isset($_POST['submit_yes'])) {
+	check_csrf_token();
+
 	$_POST['login'] = $addslashes($_POST['login']);
 
 	$sql = "DELETE FROM %sadmins WHERE login='%s'";
@@ -52,6 +54,7 @@ if(count($row_admins) == 0){
 	echo _AT('no_user_found');
 } else {
 	$hidden_vars['login'] = $_GET['login'];
+	$hidden_vars['csrftoken'] = $_SESSION['token'];
 	$confirm = array('DELETE_ADMIN', $row_admins['login']);
 	$msg->addConfirm($confirm, $hidden_vars);
 	$msg->printConfirm();

--- a/mods/_core/users/admins/edit.php
+++ b/mods/_core/users/admins/edit.php
@@ -27,6 +27,8 @@ if (isset($_POST['cancel'])) {
 	header('Location: index.php');
 	exit;
 } else if (isset($_POST['submit'])) {
+	check_csrf_token();
+
 	$missing_fields = array();
 
 	/* email validation */

--- a/mods/_core/users/admins/password.php
+++ b/mods/_core/users/admins/password.php
@@ -20,6 +20,7 @@ if (isset($_POST['cancel'])) {
 	header('Location: '.AT_BASE_HREF.'mods/_core/users/admins/index.php');
 	exit;
 } else if (isset($_POST['submit'])) {
+	check_csrf_token();
 	/* password check: password is verified front end by javascript. here is to handle the errors from javascript */
 	if ($_POST['password_error'] <> "")
 	{

--- a/mods/_core/users/admins/reset_log.php
+++ b/mods/_core/users/admins/reset_log.php
@@ -22,6 +22,7 @@ if (isset($_POST['submit_no'])) {
 	header('Location: ./log.php');
 	exit;
 } else if (isset($_POST['submit_yes'])) {
+	check_csrf_token();
 	//clean up the db
 	$sql    = "DELETE FROM %sadmin_log";
 	$result = queryDB($sql, array(TABLE_PREFIX));
@@ -37,6 +38,7 @@ require(AT_INCLUDE_PATH.'header.inc.php');
 
 //print confirmation
 $hidden_vars['all'] = TRUE;
+$hidden_vars['csrftoken'] = $_SESSION['token'];
 
 $confirm = array('RESET_ADMIN_LOG', $_SERVER['PHP_SELF']);
 $msg->addConfirm($confirm, $hidden_vars);

--- a/mods/_core/users/edit_user.php
+++ b/mods/_core/users/edit_user.php
@@ -28,6 +28,8 @@ if (isset($_POST['cancel'])) {
 }
 
 if (isset($_POST['submit'])) {
+	check_csrf_token();
+
 	$missing_fields = array();
 
 	$id = intval($_POST['id']);

--- a/mods/_core/users/instructor_requests.php
+++ b/mods/_core/users/instructor_requests.php
@@ -18,13 +18,14 @@ define('AT_INCLUDE_PATH', '../../../include/');
 require(AT_INCLUDE_PATH.'vitals.inc.php');
 admin_authenticate(AT_ADMIN_PRIV_USERS);
 
-if (isset($_GET['deny']) && isset($_GET['id'])) {
-	header('Location: admin_deny.php?id='.$_GET['id']);
+if (isset($_POST['deny']) && isset($_POST['id'])) {
+	header('Location: admin_deny.php?id='.$_POST['id']);
 	exit;
 
-} else if (isset($_GET['approve']) && isset($_GET['id'])) {
-   
-	$id = intval($_GET['id']);
+} else if (isset($_POST['approve']) && isset($_POST['id'])) {
+	check_csrf_token();
+
+	$id = intval($_POST['id']);
 
 	$sql = 'DELETE FROM %sinstructor_approvals WHERE member_id=%d';
 	$result = queryDB($sql, array(TABLE_PREFIX, $id));
@@ -69,7 +70,7 @@ if (isset($_GET['deny']) && isset($_GET['id'])) {
 	}
 
 	$msg->addFeedback('PROFILE_UPDATED_ADMIN');
-} else if (!empty($_GET) && !$_GET['submit']) {
+} else if (!empty($_POST) && !$_POST['submit']) {
 	$msg->addError('NO_ITEM_SELECTED');
 }
 

--- a/mods/_core/users/password_user.php
+++ b/mods/_core/users/password_user.php
@@ -23,6 +23,7 @@ if (isset($_POST['cancel'])) {
 	header('Location: '.AT_BASE_HREF.'mods/_core/users/users.php');
 	exit;
 } else if (isset($_POST['submit'])) {
+	check_csrf_token();
 	/* password check: password is verified front end by javascript. here is to handle the errors from javascript */
 	if ($_POST['password_error'] <> "")
 	{

--- a/mods/_standard/basiclti/tool/admin_create.php
+++ b/mods/_standard/basiclti/tool/admin_create.php
@@ -35,6 +35,7 @@ if (isset($_POST['cancel'])) {
         header('Location: '.AT_BASE_HREF.'mods/_standard/basiclti/index_admin.php');
         exit;
 } else if (isset($_POST['form_basiclti'])) {
+    check_csrf_token();
 
     if ( at_form_validate($blti_admin_form, $msg) ) {
 
@@ -65,6 +66,7 @@ $msg->printAll();
 
 ?>
 <form method="post" action="<?php echo $_SERVER['PHP_SELF'];  ?>" name="basiclti_form" enctype="multipart/form-data">
+  <input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
   <input type="hidden" name="form_basiclti" value="true" />
   <div class="input-form">
     <fieldset class="group_form"><legend class="group_form"><?php echo _AT('properties'); ?></legend>

--- a/mods/_standard/basiclti/tool/admin_delete.php
+++ b/mods/_standard/basiclti/tool/admin_delete.php
@@ -23,6 +23,7 @@ if (isset($_POST['submit_no'])) {
         header('Location: ../index_admin.php');
         exit;
 } else if (isset($_POST['submit_yes'])) {
+        check_csrf_token();
 
 		$sql = "DELETE FROM %sbasiclti_tools WHERE id =%d";
 	    $result = queryDB($sql, array(TABLE_PREFIX, $tool));
@@ -38,6 +39,7 @@ require(AT_INCLUDE_PATH.'header.inc.php');
 if (!isset($_POST['step'])) {
         $hidden_vars['step']   = 2;
         $hidden_vars['id'] = $tool;
+        $hidden_vars['csrftoken'] = $_SESSION['token'];
         $msg->addConfirm(array('DELETE_TOOL_1', $row['title']), $hidden_vars);
         $msg->printConfirm();
 } 

--- a/mods/_standard/basiclti/tool/admin_edit.php
+++ b/mods/_standard/basiclti/tool/admin_edit.php
@@ -36,6 +36,7 @@ if (isset($_POST['cancel'])) {
         header('Location: '.AT_BASE_HREF.'mods/_standard/basiclti/index_admin.php');
         exit;
 } else if (isset($_POST['form_basiclti'], $tool)) {
+    check_csrf_token();
 
     if ( at_form_validate($blti_admin_form, $msg) ) {
         $sql = "SELECT count(*) cnt FROM %sbasiclti_tools WHERE toolid = '%s' AND id != %d";
@@ -73,6 +74,7 @@ $msg->printAll();
 <form method="post" action="<?php echo $_SERVER['PHP_SELF'];  ?>" name="basiclti_form" enctype="multipart/form-data">
   <input type="hidden" name="form_basiclti" value="true" />
   <input type="hidden" name="id" value="<?php echo $tool; ?>" />
+  <input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
   <div class="input-form">
     <fieldset class="group_form"><legend class="group_form"><?php echo _AT('properties'); ?></legend>
 <?php at_form_generate($toolrow, $blti_admin_form); ?>

--- a/mods/_standard/patcher/classes/Patch.class.php
+++ b/mods/_standard/patcher/classes/Patch.class.php
@@ -302,6 +302,7 @@ class Patch {
 			}
 
 			$notes = '<form action="'. $_SERVER['PHP_SELF'].'?id='.$id.'&who='. $who .'" method="post" name="skip_files_modified">
+		  <input type="hidden" name="csrftoken"  value="'.$_SESSION['token'].'" />
 		  <div class="row buttons">
 				<input type="submit" name="yes" value="'._AT('continue').'" accesskey="y" />
 				<input type="submit" name="no" value="'. _AT('cancel'). '" />
@@ -337,6 +338,7 @@ class Patch {
 				
 			$notes = '
 			  <form action="'. $_SERVER['PHP_SELF'].'?id='.$_POST['id'].'&who='. $_POST['who'] .'" method="post" name="skip_files_modified">
+			  <input type="hidden" name="csrftoken"  value="'.$_SESSION['token'].'" />
 			  <div class="row buttons">
 					<input type="submit" name="ignore_version" value="'._AT('yes').'" accesskey="y" />
 					<input type="submit" name="not_ignore_version" value="'. _AT('no'). '" />
@@ -453,6 +455,7 @@ class Patch {
 			else
 				$notes = '
 			  <form action="'. $_SERVER['PHP_SELF'].'?id='.$_POST['id'].'&who='. $_POST['who'] .'" method="post" name="skip_files_modified">
+			  <input type="hidden" name="csrftoken"  value="'.$_SESSION['token'].'" />
 			  <div class="row buttons">
 					<input type="submit" name="yes" value="'._AT('yes').'" accesskey="y" />
 					<input type="submit" name="no" value="'. _AT('no'). '" />

--- a/mods/_standard/patcher/index_admin.php
+++ b/mods/_standard/patcher/index_admin.php
@@ -130,6 +130,7 @@ if ($_POST['install_upload'] && $_POST['uploading'])
 // Installation process
 if ($_POST['install'] || $_POST['install_upload'] && !isset($_POST["not_ignore_version"]))
 {
+	check_csrf_token();
 	
 	if (isset($_POST['id'])) $id=$_POST['id'];
 	else $id = $_REQUEST['id'];
@@ -309,6 +310,7 @@ $msg->printAll();
 ?>
 
 <form action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post" name="form">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <div class="input-form">
 
 <table class="data" summary="" style="width: 100%">

--- a/registration.php
+++ b/registration.php
@@ -34,6 +34,8 @@ if (isset($_POST['cancel'])) {
         header('Location: ./login.php');
 	exit;
 } else if (isset($_POST['submit'])) {
+	check_csrf_token();
+
     if(isset($_SESSION['member_id']) && $_SESSION['member_id'] > 0 && $_SESSION['login']) {
         $member_id = $_SESSION['member_id'];
         require (AT_INCLUDE_PATH.'html/auto_enroll_courses.inc.php');
@@ -51,14 +53,6 @@ if (isset($_POST['cancel'])) {
     }
     
 	$missing_fields = array();
-
-	/* registration token validation */
-	if (sha1($_SESSION['token']) != $_POST['registration_token']){
-		//Prevent registration from any other pages other than the ATutor pages.
-		//SHA1(SESSION[token]) so that no one knows what the actual token is, thus cannot recreate it on another page.
-		header('Location: ./login.php');
-		exit;
-	}
 
 	/* email check */
 	$chk_email = $addslashes($_POST['email']);

--- a/themes/default/admin/courses/edit_course.tmpl.php
+++ b/themes/default/admin/courses/edit_course.tmpl.php
@@ -4,6 +4,7 @@ global $languageManager,  $_config, $MaxCourseSize, $MaxFileSize;
 ?>
 <?php //echo _AT('available_immediately'); ?>
 <form method="post" action="<?php echo $_SERVER['PHP_SELF'];  ?>" name="course_form" enctype="multipart/form-data">
+	<input type="hidden" name="csrftoken"  value="<?php echo $_SESSION['token'];?>" />
 	<input type="hidden" name="form_course" value="true" />
 	<input type="hidden" name="MAX_FILE_SIZE" value="<?php echo $_config['prof_pic_max_file_size']; ?>" />
 	<input type="hidden" name="course" value="<?php echo $this->course; ?>" />
@@ -12,7 +13,6 @@ global $languageManager,  $_config, $MaxCourseSize, $MaxFileSize;
 	<input type="hidden" name="show_courses" value="<?php echo intval($_GET['show_courses']); ?>" />
 	<input type="hidden" name="current_cat" value="<?php echo intval($_GET['current_cat']); ?>" />
 	<input type="submit" name="submit" style="display:none;"/>
-	<input type="hidden" name="csrftoken"  value="<?php echo $_SESSION['token'];?>" />
 
 <div class="input-form">
 	<fieldset class="group_form"><legend class="group_form"><?php echo _AT('properties'); ?></legend>

--- a/themes/default/admin/system_preferences/config_edit.tmpl.php
+++ b/themes/default/admin/system_preferences/config_edit.tmpl.php
@@ -1,6 +1,7 @@
 <?php global $_config, $languageManager, $_config_defaults, $stripslashes;?>
 
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>" name="form">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <div class="input-form">
 	<div class="row">
 		<span class="required" title="<?php echo _AT('required_field'); ?>">*</span><label for="sitename"><?php echo _AT('site_name'); ?></label><br />

--- a/themes/default/admin/users/admin_email.tmpl.php
+++ b/themes/default/admin/users/admin_email.tmpl.php
@@ -1,5 +1,6 @@
 
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>" name="form">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <input type="hidden" name="admin" value="admin" />
 
 <div class="input-form">

--- a/themes/default/admin/users/edit.tmpl.php
+++ b/themes/default/admin/users/edit.tmpl.php
@@ -1,4 +1,5 @@
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>" name="form">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <input type="hidden" name="login" value="<?php echo  $this->login; ?>" />
 <input type="hidden" name="hide_email" value="<?php echo  $this->hide_email; ?>" />
 <div class="input-form">

--- a/themes/default/admin/users/instructor_requests.tmpl.php
+++ b/themes/default/admin/users/instructor_requests.tmpl.php
@@ -1,5 +1,6 @@
 
-<form name="form" method="get" action="<?php echo $_SERVER['PHP_SELF']; ?>">
+<form name="form" method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <table class="data" summary="Table listing instructor requests">
 <thead>
 <tr>

--- a/themes/default/admin/users/password.tmpl.php
+++ b/themes/default/admin/users/password.tmpl.php
@@ -1,4 +1,5 @@
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>" name="form">
+	<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 	<input type="hidden" name="login" value="<?php echo $this->row['login']; ?>" />
 	<input type="hidden" name="form_password_hidden" value="" />
 	<input type="hidden" name="password_error" value="" />

--- a/themes/default/admin/users/password_user.tmpl.php
+++ b/themes/default/admin/users/password_user.tmpl.php
@@ -1,5 +1,6 @@
 
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>" name="form">
+	<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 	<input type="hidden" name="id" value="<?php echo $this->id; ?>" />
 	<input type="hidden" name="form_password_hidden" value="" />
 	<input type="hidden" name="password_error" value="" />

--- a/themes/default/registration.tmpl.php
+++ b/themes/default/registration.tmpl.php
@@ -70,7 +70,7 @@ function show_login_form()
 <input name="ml" type="hidden" value="<?php if(isset($this->ml)){ echo $this->ml; } ?>" />
 <input name="password_error" type="hidden" />
 <input type="hidden" name="form_password_hidden" value="" />
-<input type="hidden" name="registration_token" value="<?php echo sha1($_SESSION['token']); ?>" />
+<input name="csrftoken" type="hidden" value="<?php echo $_SESSION['token']; ?>" />
 
 <div class="input-form">
 <fieldset class="group_form"><legend class="group_form"><?php echo _AT('required_information'); ?></legend>

--- a/themes/mobile/admin/courses/edit_course.tmpl.php
+++ b/themes/mobile/admin/courses/edit_course.tmpl.php
@@ -4,6 +4,7 @@ global $languageManager,  $_config, $MaxCourseSize, $MaxFileSize;
 ?>
 <?php //echo _AT('available_immediately'); ?>
 <form method="post" action="<?php echo $_SERVER['PHP_SELF'];  ?>" name="course_form" enctype="multipart/form-data">
+	<input type="hidden" name="csrftoken"  value="<?php echo $_SESSION['token'];?>" />
 	<input type="hidden" name="form_course" value="true" />
 	<input type="hidden" name="MAX_FILE_SIZE" value="<?php echo $_config['prof_pic_max_file_size']; ?>" />
 	<input type="hidden" name="course" value="<?php echo $this->course; ?>" />

--- a/themes/mobile/admin/system_preferences/config_edit.tmpl.php
+++ b/themes/mobile/admin/system_preferences/config_edit.tmpl.php
@@ -1,6 +1,7 @@
 <?php global $_config, $languageManager, $_config_defaults, $stripslashes;?>
 
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>" name="form">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <div class="input-form">
 	<div class="row">
 		<span class="required" title="<?php echo _AT('required_field'); ?>">*</span><label for="sitename"><?php echo _AT('site_name'); ?></label><br />

--- a/themes/mobile/admin/users/admin_email.tmpl.php
+++ b/themes/mobile/admin/users/admin_email.tmpl.php
@@ -1,5 +1,6 @@
 
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>" name="form">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <input type="hidden" name="admin" value="admin" />
 
 <div class="input-form">

--- a/themes/mobile/admin/users/instructor_requests.tmpl.php
+++ b/themes/mobile/admin/users/instructor_requests.tmpl.php
@@ -1,5 +1,6 @@
 
-<form name="form" method="get" action="<?php echo $_SERVER['PHP_SELF']; ?>">
+<form name="form" method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <div class="table-surround">
 <table class="data" summary="Table listing instructor requets" >
 <thead>

--- a/themes/mobile/registration.tmpl.php
+++ b/themes/mobile/registration.tmpl.php
@@ -70,7 +70,7 @@ function show_login_form()
 <input name="ml" type="hidden" value="<?php if(isset($this->ml)){ echo $this->ml; } ?>" />
 <input name="password_error" type="hidden" />
 <input type="hidden" name="form_password_hidden" value="" />
-<input type="hidden" name="registration_token" value="<?php echo sha1($_SESSION['token']); ?>" />
+<input name="csrftoken" type="hidden" value="<?php echo $_SESSION['token']; ?>" />
 
 <div class="input-form">
 <fieldset class="group_form"><legend class="group_form"><?php echo _AT('required_information'); ?></legend>

--- a/themes/simplified_desktop/admin/courses/edit_course.tmpl.php
+++ b/themes/simplified_desktop/admin/courses/edit_course.tmpl.php
@@ -5,6 +5,7 @@ global $languageManager,  $_config, $MaxCourseSize, $MaxFileSize;
 ?>
 <?php //echo _AT('available_immediately'); ?>
 <form method="post" action="<?php echo $_SERVER['PHP_SELF'];  ?>" name="course_form" enctype="multipart/form-data">
+	<input type="hidden" name="csrftoken"  value="<?php echo $_SESSION['token'];?>" />
 	<input type="hidden" name="form_course" value="true" />
 	<input type="hidden" name="MAX_FILE_SIZE" value="<?php echo $_config['prof_pic_max_file_size']; ?>" />
 	<input type="hidden" name="course" value="<?php echo $this->course; ?>" />

--- a/themes/simplified_desktop/admin/system_preferences/config_edit.tmpl.php
+++ b/themes/simplified_desktop/admin/system_preferences/config_edit.tmpl.php
@@ -1,6 +1,7 @@
 <?php global $_config, $languageManager, $_config_defaults, $stripslashes;?>
 
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>" name="form">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <div class="input-form">
 	<div class="row">
 		<span class="required" title="<?php echo _AT('required_field'); ?>">*</span><label for="sitename"><?php echo _AT('site_name'); ?></label><br />

--- a/themes/simplified_desktop/admin/users/admin_email.tmpl.php
+++ b/themes/simplified_desktop/admin/users/admin_email.tmpl.php
@@ -1,5 +1,6 @@
 
 <form method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>" name="form">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <input type="hidden" name="admin" value="admin" />
 
 <div class="input-form">

--- a/themes/simplified_desktop/admin/users/instructor_requests.tmpl.php
+++ b/themes/simplified_desktop/admin/users/instructor_requests.tmpl.php
@@ -1,5 +1,6 @@
 
-<form name="form" method="get" action="<?php echo $_SERVER['PHP_SELF']; ?>">
+<form name="form" method="post" action="<?php echo $_SERVER['PHP_SELF']; ?>">
+<input type="hidden" name="csrftoken" value="<?php echo $_SESSION['token'];?>" />
 <div class="table-surround">
 <table class="data" summary="Table listing instructor requets" >
 <thead>

--- a/themes/simplified_desktop/registration.tmpl.php
+++ b/themes/simplified_desktop/registration.tmpl.php
@@ -70,7 +70,7 @@ function show_login_form()
 <input name="ml" type="hidden" value="<?php if(isset($this->ml)){ echo $this->ml; } ?>" />
 <input name="password_error" type="hidden" />
 <input type="hidden" name="form_password_hidden" value="" />
-<input type="hidden" name="registration_token" value="<?php echo sha1($_SESSION['token']); ?>" />
+<input name="csrftoken" type="hidden" value="<?php echo $_SESSION['token']; ?>" />
 
 <div class="input-form">
 <fieldset class="group_form"><legend class="group_form"><?php echo _AT('required_information'); ?></legend>


### PR DESCRIPTION
Several administrator actions are not protected from CSRF attacks, which the application should be able to distinguish from genuine requests. The changes proposed here expand the use of the anti-CSRF tokens, which are already in place in some pages, to cover most of the administrator actions, with a focus on the high-impact actions (for example privilege escalation). 

Some minor refactoring is also suggested: 
- Consistently name the anti-CSRF token "csrftoken", as both this name and "registration_token" was in use before, to make their purpose clear.
- Moved error handling to new function in vital.funcs.inc.php (it might help to add a more descriptive error message)
- Actions for accepting instructor requests was previously GET-requests, but was changed to the POST method, due to the addition of the secret anti-CSRF-token.

To verify the vulnerabilities and the fixes I build HTML pages that submit server requests for each action, which can be found in the attached zip-file (replace the Host URL and ID-values where appropriate to make use of them). The following actions have CSRF protection added: 
- Approve instructor request
- Change enrollment status
- Change system preferences
- Create course
- Delete admin activity
- Delete admin
- Delete course
- Edit admin password
- Edit admin privileges
- Edit course
- Edit user password
- Edit user
- Email users
- Create external tool
- Delete external tool
- Edit external tool
- Install patch



















[ATutor CSRF tests.zip](https://github.com/atutor/ATutor/files/692870/ATutor.CSRF.tests.zip)
