### PR TITLE
fix concat bug in php

### DIFF
--- a/password_reminder.php
+++ b/password_reminder.php
@@ -34,7 +34,7 @@ if (isset($_POST['cancel'])) {
 		//date link was generated (# days since epoch)
 		$gen = intval(((time()/60)/60)/24);
 
-		$hash = sha1($row['member_id'] + $gen + $row['password']);
+		$hash = sha1($row['member_id'] . $gen . $row['password']);
 		$hash_bit = substr($hash, 5, 15);
 		
 		$change_link = $_base_href.'password_reminder.php?id='.$row['member_id'].'&g='.$gen.'&h='.$hash_bit;
@@ -91,7 +91,7 @@ if (isset($_POST['cancel'])) {
 	if (isset($row['email']) && $row['email'] != '') {
 		$email = $row['email'];
 
-		$hash = sha1($_REQUEST['id'] + $_REQUEST['g'] + $row['password']);
+		$hash = sha1($_REQUEST['id'] . $_REQUEST['g'] . $row['password']);
 		$hash_bit = substr($hash, 5, 15);
 
 		if ($_REQUEST['h'] !== $hash_bit) {


### PR DESCRIPTION
php should now concat the strings and not calculate them. hash should now be working correct and not be easy guessable.